### PR TITLE
feat: Implement categories list screen

### DIFF
--- a/PocketChef/Application/SceneDelegate.swift
+++ b/PocketChef/Application/SceneDelegate.swift
@@ -13,18 +13,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-         guard let windowScene = (scene as? UIWindowScene) else { return }
+        guard let windowScene = (scene as? UIWindowScene) else { return }
         
-         let window = UIWindow(windowScene: windowScene)
-
-         let rootViewController = UIViewController()
-         rootViewController.view.backgroundColor = .red
-
-         window.rootViewController = rootViewController
-
-         self.window = window
+        let window = UIWindow(windowScene: windowScene)
         
-         window.makeKeyAndVisible()
+        let categoriesViewController = CategoriesViewController()
+        
+        let navigationController = UINavigationController(rootViewController: categoriesViewController)
+        
+        window.rootViewController = navigationController
+        
+        self.window = window
+        
+        window.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/PocketChef/Core/Networking/NetworkError.swift
+++ b/PocketChef/Core/Networking/NetworkError.swift
@@ -1,0 +1,33 @@
+//
+//  NetworkError.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 16/09/25.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL
+    case requestFailed(Error)
+    case invalidResponse
+    case serverError(statusCode: Int)
+    case decodingFailed(Error)
+}
+
+extension NetworkError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "The provided URL is invalid."
+        case .requestFailed(let error):
+            return "The request failed. Original error: \(error.localizedDescription)"
+        case .invalidResponse:
+            return "The server response was invalid (not an HTTP response)."
+        case .serverError(let statusCode):
+            return "The server returned an error with status: \(statusCode)."
+        case .decodingFailed(let error):
+            return "Failed to decode the JSON response. Error: \(error.localizedDescription)"
+        }
+    }
+}

--- a/PocketChef/Core/Networking/NetworkService.swift
+++ b/PocketChef/Core/Networking/NetworkService.swift
@@ -1,0 +1,54 @@
+//
+//  NetworkService.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 16/09/25.
+//
+
+import Foundation
+
+final class NetworkService: NetworkServiceProtocol {
+    
+    func request<T: Decodable>(urlString: String, completion: @escaping (Result<T, NetworkError>) -> Void) {
+        
+        guard let url = URL(string: urlString) else {
+            completion(.failure(.invalidURL))
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            let result = self.handleResponse(data: data, response: response, error: error) as Result<T, NetworkError>
+            
+            DispatchQueue.main.async {
+                completion(result)
+            }
+        }
+        
+        task.resume()
+    }
+    
+    private func handleResponse<T: Decodable>(data: Data?, response: URLResponse?, error: Error?) -> Result<T, NetworkError> {
+        if let error = error {
+            return .failure(.requestFailed(error))
+        }
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return .failure(.invalidResponse)
+        }
+        
+        guard (200...299).contains(httpResponse.statusCode) else {
+            return .failure(.serverError(statusCode: httpResponse.statusCode))
+        }
+        
+        guard let data = data else {
+            return .failure(.invalidResponse)
+        }
+        
+        do {
+            let decodedObject = try JSONDecoder().decode(T.self, from: data)
+            return .success(decodedObject)
+        } catch {
+            return .failure(.decodingFailed(error))
+        }
+    }
+}

--- a/PocketChef/Core/Networking/NetworkServiceProtocol.swift
+++ b/PocketChef/Core/Networking/NetworkServiceProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  NetworkServiceProtocol.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 16/09/25.
+//
+
+import Foundation
+
+protocol NetworkServiceProtocol {
+    func request<T: Decodable>(urlString: String, completion: @escaping (Result<T, NetworkError>) -> Void)
+}

--- a/PocketChef/Features/Categories/Model/Category.swift
+++ b/PocketChef/Features/Categories/Model/Category.swift
@@ -1,0 +1,26 @@
+//
+//  Category.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 16/09/25.
+//
+
+import Foundation
+
+struct CategoriesResponse: Decodable {
+    let categories: [Category]
+}
+
+struct Category: Decodable {
+    let id: String
+    let name: String
+    let thumbnailURL: String
+    let description: String
+
+    enum CodingKeys: String, CodingKey {
+        case id = "idCategory"
+        case name = "strCategory"
+        case thumbnailURL = "strCategoryThumb"
+        case description = "strCategoryDescription"
+    }
+}

--- a/PocketChef/Features/Categories/View/CategoriesView.swift
+++ b/PocketChef/Features/Categories/View/CategoriesView.swift
@@ -1,0 +1,53 @@
+//
+//  CategoriesView.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 17/09/25.
+//
+
+import Foundation
+import UIKit
+
+final class CategoriesView: UIView {
+    
+    let tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "CategoryCell")
+        return tableView
+    }()
+    
+    let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    private func setupView() {
+        backgroundColor = .systemBackground
+        
+        addSubview(tableView)
+        addSubview(activityIndicator)
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}

--- a/PocketChef/Features/Categories/View/CategoriesViewController.swift
+++ b/PocketChef/Features/Categories/View/CategoriesViewController.swift
@@ -1,0 +1,83 @@
+//
+//  CategoriesViewController.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 17/09/25.
+//
+
+import Foundation
+import UIKit
+
+final class CategoriesViewController: UIViewController {
+    
+    private let viewModel: CategoriesViewModelProtocol
+    
+    private var customView: CategoriesView? {
+        return view as? CategoriesView
+    }
+    
+    
+    init(viewModel: CategoriesViewModelProtocol = CategoriesViewModel()) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        self.view = CategoriesView()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Categories"
+        
+        setupTableView()
+        setupBindings()
+        
+        customView?.activityIndicator.startAnimating()
+        viewModel.fetchCategories()
+    }
+    
+    // MARK: - Private Methods
+    
+    private func setupTableView() {
+        customView?.tableView.dataSource = self
+    }
+    
+    private func setupBindings() {
+        viewModel.onCategoriesUpdated = { [weak self] in
+            DispatchQueue.main.async {
+                self?.customView?.tableView.reloadData()
+                self?.customView?.activityIndicator.stopAnimating()
+            }
+        }
+        
+        viewModel.onFetchError = { [weak self] errorMessage in
+            DispatchQueue.main.async {
+                print("Error fetching categories: \(errorMessage)")
+                self?.customView?.activityIndicator.stopAnimating()
+            }
+        }
+    }
+}
+
+extension CategoriesViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.numberOfCategories
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "CategoryCell", for: indexPath)
+        
+        if let category = viewModel.category(at: indexPath.row) {
+            var content = cell.defaultContentConfiguration()
+            content.text = category.name
+            cell.contentConfiguration = content
+        }
+        
+        return cell
+    }
+}

--- a/PocketChef/Features/Categories/ViewModel/CategoriesViewModel.swift
+++ b/PocketChef/Features/Categories/ViewModel/CategoriesViewModel.swift
@@ -1,0 +1,49 @@
+//
+//  CategoriesViewModel.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 17/09/25.
+//
+
+import Foundation
+
+final class CategoriesViewModel: CategoriesViewModelProtocol {
+    
+    var onCategoriesUpdated: (() -> Void)?
+    var onFetchError: ((String) -> Void)?
+    
+    private var categories: [Category] = []
+    private let networkService: NetworkServiceProtocol
+    private let categoriesURL = "https://www.themealdb.com/api/json/v1/1/categories.php"
+    
+    init(networkService: NetworkServiceProtocol = NetworkService()) {
+        self.networkService = networkService
+    }
+    
+    var numberOfCategories: Int {
+        return categories.count
+    }
+    
+    func category(at index: Int) -> Category? {
+        guard index >= 0 && index < categories.count else {
+            return nil
+        }
+        return categories[index]
+    }
+    
+    func fetchCategories() {
+        networkService.request(urlString: categoriesURL) { [weak self] (result: Result<CategoriesResponse, NetworkError>) in
+            guard let self = self else { return }
+            
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let response):
+                    self.categories = response.categories
+                    self.onCategoriesUpdated?()
+                case .failure(let error):
+                    self.onFetchError?(error.localizedDescription)
+                }
+            }
+        }
+    }
+}

--- a/PocketChef/Features/Categories/ViewModel/CategoriesViewModelProtocol.swift
+++ b/PocketChef/Features/Categories/ViewModel/CategoriesViewModelProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  CategoriesViewModelProtocol.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 16/09/25.
+//
+
+import Foundation
+
+protocol CategoriesViewModelProtocol: AnyObject {
+    var onCategoriesUpdated: (() -> Void)? { get set }
+    var onFetchError: ((String) -> Void)? { get set }
+    var numberOfCategories: Int { get }
+    func category(at index: Int) -> Category?
+    func fetchCategories()
+}


### PR DESCRIPTION
This PR introduces the first core feature of the Pocket Chef app: the ability to fetch and display a list of meal categories from TheMealDB API.

It establishes the foundational architecture (MVVM), networking, and UI patterns (ViewCode with a custom UIView) that will be used throughout the project.

Key Implementation Details
Project Setup: The project was configured for a fully programmatic UI (ViewCode), removing all Storyboard dependencies to improve maintainability and version control.

Networking Layer: A robust and reusable NetworkService was created using native URLSession. It's a generic service that leverages Swift's Result type for clear and safe asynchronous error handling.

MVVM Architecture: The feature was built following the Model-View-ViewModel pattern for a clean separation of concerns:

Model: A Decodable Category struct to parse the API response.

View: A custom CategoriesView class responsible only for building and laying out the UI, and a CategoriesViewController that manages the view lifecycle and binds it to the ViewModel.

ViewModel: A CategoriesViewModel that handles the business logic, fetches data via the network service, and exposes the state to the View through closures (data binding).

Protocol-Oriented Design: Wrote NetworkServiceProtocol and CategoriesViewModelProtocol to enable Dependency Injection, making the components decoupled and highly testable. The ViewModel protocol was constrained to AnyObject to enforce reference-type semantics.

How to Test
Pull down this branch (feature/categories-list).

Run the app on a simulator.

On launch, a loading indicator should appear briefly.

The indicator will be replaced by a UITableView populated with a list of meal categories fetched from the API (e.g., "Beef", "Chicken", "Dessert").