### PR TITLE
feat: Implement meals list screen and navigation

### DIFF
--- a/PocketChef/Application/SceneDelegate.swift
+++ b/PocketChef/Application/SceneDelegate.swift
@@ -10,22 +10,21 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    var mainCoordinator: MainCoordinator?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
+        let navigationController = UINavigationController()
         
-        let categoriesViewController = CategoriesViewController()
-        
-        let navigationController = UINavigationController(rootViewController: categoriesViewController)
+        mainCoordinator = MainCoordinator(navigationController: navigationController)
+        mainCoordinator?.start()
         
         window.rootViewController = navigationController
-        
         self.window = window
-        
         window.makeKeyAndVisible()
+
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/PocketChef/Core/Coordinator/Coordinator.swift
+++ b/PocketChef/Core/Coordinator/Coordinator.swift
@@ -1,0 +1,15 @@
+//
+//  Coordinator.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 20/09/25.
+//
+
+import Foundation
+import UIKit
+
+protocol Coordinator: AnyObject {
+    var navigationController: UINavigationController { get set }
+    
+    func start()
+}

--- a/PocketChef/Core/Coordinator/MainCoordinator.swift
+++ b/PocketChef/Core/Coordinator/MainCoordinator.swift
@@ -1,0 +1,26 @@
+//
+//  MainCoordinator.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 20/09/25.
+//
+
+import Foundation
+import UIKit
+
+final class MainCoordinator: Coordinator {
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let viewController = CategoriesViewController()
+        navigationController.pushViewController(viewController, animated: false)
+    }
+    
+    func showMeals(for category: Category) {
+        print("Coordinator was told to show meals for: \(category.name)")
+    }
+}

--- a/PocketChef/Core/Coordinator/MainCoordinator.swift
+++ b/PocketChef/Core/Coordinator/MainCoordinator.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-final class MainCoordinator: Coordinator {
+final class MainCoordinator: Coordinator, CategoriesViewControllerDelegate {
     var navigationController: UINavigationController
     
     init(navigationController: UINavigationController) {
@@ -17,10 +17,16 @@ final class MainCoordinator: Coordinator {
     
     func start() {
         let viewController = CategoriesViewController()
+        viewController.delegate = self
         navigationController.pushViewController(viewController, animated: false)
     }
     
     func showMeals(for category: Category) {
-        print("Coordinator was told to show meals for: \(category.name)")
+    }
+}
+
+extension MainCoordinator {
+    func categoriesViewController(_ controller: CategoriesViewController, didSelectCategory category: Category) {
+        showMeals(for: category)
     }
 }

--- a/PocketChef/Core/Coordinator/MainCoordinator.swift
+++ b/PocketChef/Core/Coordinator/MainCoordinator.swift
@@ -22,6 +22,9 @@ final class MainCoordinator: Coordinator, CategoriesViewControllerDelegate {
     }
     
     func showMeals(for category: Category) {
+        let viewModel = MealsViewModel(category: category)
+        let viewController = MealsViewController(viewModel: viewModel)
+        navigationController.pushViewController(viewController, animated: true)
     }
 }
 

--- a/PocketChef/Features/Categories/View/CategoriesViewController.swift
+++ b/PocketChef/Features/Categories/View/CategoriesViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 final class CategoriesViewController: UIViewController {
     
     private let viewModel: CategoriesViewModelProtocol
+    weak var delegate: CategoriesViewControllerDelegate? 
     
     private var customView: CategoriesView? {
         return view as? CategoriesView
@@ -45,6 +46,7 @@ final class CategoriesViewController: UIViewController {
     
     private func setupTableView() {
         customView?.tableView.dataSource = self
+        customView?.tableView.delegate = self
     }
     
     private func setupBindings() {
@@ -79,5 +81,17 @@ extension CategoriesViewController: UITableViewDataSource {
         }
         
         return cell
+    }
+}
+
+extension CategoriesViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+    
+        guard let selectedCategory = viewModel.category(at: indexPath.row) else {
+            return
+        }
+        
+        delegate?.categoriesViewController(self, didSelectCategory: selectedCategory)
     }
 }

--- a/PocketChef/Features/Categories/View/CategoriesViewControllerDelegate.swift
+++ b/PocketChef/Features/Categories/View/CategoriesViewControllerDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  CategoriesViewControllerDelegate.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 20/09/25.
+//
+
+import Foundation
+
+protocol CategoriesViewControllerDelegate: AnyObject {
+    func categoriesViewController(_ controller: CategoriesViewController, didSelectCategory category: Category)
+}

--- a/PocketChef/Features/Meals/Model/Meal.swift
+++ b/PocketChef/Features/Meals/Model/Meal.swift
@@ -1,0 +1,24 @@
+//
+//  Meal.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 20/09/25.
+//
+
+import Foundation
+
+struct MealsResponse: Decodable {
+    let meals: [Meal]
+}
+
+struct Meal: Decodable, Hashable {
+    let id: String
+    let name: String
+    let thumbnailURLString: String
+
+    enum CodingKeys: String, CodingKey {
+        case id = "idMeal"
+        case name = "strMeal"
+        case thumbnailURLString = "strMealThumb"
+    }
+}

--- a/PocketChef/Features/Meals/View/MealsView.swift
+++ b/PocketChef/Features/Meals/View/MealsView.swift
@@ -1,0 +1,52 @@
+//
+//  MealsView.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 20/09/25.
+//
+
+import Foundation
+import UIKit
+
+final class MealsView: UIView {
+    
+    let tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "MealCell")
+        return tableView
+    }()
+    
+    let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        backgroundColor = .systemBackground
+        
+        addSubview(tableView)
+        addSubview(activityIndicator)
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}

--- a/PocketChef/Features/Meals/View/MealsViewController.swift
+++ b/PocketChef/Features/Meals/View/MealsViewController.swift
@@ -1,0 +1,79 @@
+//
+//  MealsViewController.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 20/09/25.
+//
+
+import Foundation
+import UIKit
+
+final class MealsViewController: UIViewController {
+    
+    private let viewModel: MealsViewModelProtocol
+    private var customView: MealsView? {
+        return view as? MealsView
+    }
+    
+    init(viewModel: MealsViewModelProtocol) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        self.view = MealsView()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupView()
+        setupTableView()
+        setupBindings()
+        
+        customView?.activityIndicator.startAnimating()
+        viewModel.fetchMeals()
+    }
+    
+    private func setupView() {
+        title = viewModel.screenTitle
+    }
+    
+    private func setupTableView() {
+        customView?.tableView.dataSource = self
+    }
+    
+    private func setupBindings() {
+        viewModel.onMealsUpdated = { [weak self] in
+            self?.customView?.tableView.reloadData()
+            self?.customView?.activityIndicator.stopAnimating()
+        }
+        
+        viewModel.onFetchError = { [weak self] errorMessage in
+            print("Error fetching meals: \(errorMessage)")
+            self?.customView?.activityIndicator.stopAnimating()
+        }
+    }
+}
+
+extension MealsViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.numberOfMeals
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "MealCell", for: indexPath)
+        
+        if let meal = viewModel.meal(at: indexPath.row) {
+            var content = cell.defaultContentConfiguration()
+            content.text = meal.name
+            cell.contentConfiguration = content
+        }
+        
+        return cell
+    }
+}

--- a/PocketChef/Features/Meals/ViewModel/MealsViewModel.swift
+++ b/PocketChef/Features/Meals/ViewModel/MealsViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  MealsViewModel.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 20/09/25.
+//
+
+import Foundation
+
+final class MealsViewModel: MealsViewModelProtocol {
+    
+    var onMealsUpdated: (() -> Void)?
+    var onFetchError: ((String) -> Void)?
+    
+    private var meals: [Meal] = []
+    private let category: Category
+    private let networkService: NetworkServiceProtocol
+    private let baseURL = "https://www.themealdb.com/api/json/v1/1/filter.php?c="
+    
+    init(category: Category, networkService: NetworkServiceProtocol = NetworkService()) {
+        self.category = category
+        self.networkService = networkService
+    }
+    
+    var screenTitle: String {
+        return "\(category.name) Meals"
+    }
+    
+    var numberOfMeals: Int {
+        return meals.count
+    }
+    
+    func meal(at index: Int) -> Meal? {
+        guard index >= 0 && index < meals.count else {
+            return nil
+        }
+        return meals[index]
+    }
+    
+    func fetchMeals() {
+        let urlString = baseURL + category.name
+        
+        networkService.request(urlString: urlString) { [weak self] (result: Result<MealsResponse, NetworkError>) in
+            guard let self = self else { return }
+            
+            switch result {
+            case .success(let response):
+                self.meals = response.meals.sorted { $0.name < $1.name }
+                self.onMealsUpdated?()
+            case .failure(let error):
+                self.onFetchError?(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/PocketChef/Features/Meals/ViewModel/MealsViewModelProtocol.swift
+++ b/PocketChef/Features/Meals/ViewModel/MealsViewModelProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  MealsViewModelProtocol.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 20/09/25.
+//
+
+import Foundation
+
+protocol MealsViewModelProtocol: AnyObject {
+    var onMealsUpdated: (() -> Void)? { get set }
+    var onFetchError: ((String) -> Void)? { get set }
+    var screenTitle: String { get }
+    var numberOfMeals: Int { get }
+    
+    func meal(at index: Int) -> Meal?
+    func fetchMeals()
+}


### PR DESCRIPTION
Com certeza. Aqui ficam um título e uma descrição completos para o Pull Request da feature que acabamos de construir.

Pull Request Title:
feat: Implement meals list screen and navigation

Pull Request Description:
Summary
This PR introduces the second major feature of the app: the ability for a user to select a category and navigate to a new screen displaying a list of meals within that category.

A significant part of this work involved establishing a scalable navigation architecture by implementing the Coordinator and Delegate design patterns, which now handle the application's flow.

Key Changes & Implementation Details
1. Architectural Enhancements (Navigation):

Coordinator Pattern:

Introduced a Coordinator protocol and a MainCoordinator to manage all navigation logic, decoupling ViewControllers from one another.

The SceneDelegate was refactored to hand over control to the MainCoordinator on launch.

Delegate Pattern:

Implemented the delegate pattern for communication from the CategoriesViewController back to the MainCoordinator.

The ViewController now announces that a category was selected without needing to know who is listening or what will happen next, adhering to the Single Responsibility Principle.

2. New Feature: Meals List Screen

MVVM Architecture: The new screen was built following the established MVVM + custom UIView pattern for consistency and predictability.

Model: A Meal model was created to parse the simplified meal data from the API's filter endpoint.

ViewModel: The MealsViewModel is initialized with a Category context, using it to construct the API request and provide a dynamic title for the screen.

View: A MealsViewController and MealsView were created to manage the view lifecycle and render the list of meals.

Navigation: The MainCoordinator now handles the creation of the MealsViewModel and MealsViewController, injecting the dependencies and pushing the new screen onto the navigation stack.

How to Test
Pull down this branch (feature/meals-list).

Run the app on a simulator.

The main categories list should appear as before.

Tap on any category (e.g., "Seafood", "Beef").

The app should smoothly navigate to a new screen.

The new screen's title should reflect the chosen category (e.g., "Seafood Meals").

A loading indicator will appear, followed by a list of meals for that category.

