### PR TITLE
feat: Implement custom cell for meal lists

### DIFF
--- a/PocketChef/Core/UIComponents/MealCell.swift
+++ b/PocketChef/Core/UIComponents/MealCell.swift
@@ -1,0 +1,67 @@
+//
+//  MealCell.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 25/09/25.
+//
+
+import Foundation
+// Em: Core/UIComponents/MealCell.swift
+
+import UIKit
+
+final class MealCell: UITableViewCell {
+    
+    static let reuseIdentifier = "MealCell"
+    
+    private let mealImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 8
+        imageView.backgroundColor = .systemGray5
+        return imageView
+    }()
+    
+    private let mealNameLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 17, weight: .semibold)
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configure(with mealName: String, imageURL: URL?) {
+        mealNameLabel.text = mealName
+        mealImageView.loadImage(from: imageURL)
+    }
+    
+    private func setupView() {
+        contentView.addSubview(mealImageView)
+        contentView.addSubview(mealNameLabel)
+        
+        NSLayoutConstraint.activate([
+            mealImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            mealImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            mealImageView.widthAnchor.constraint(equalToConstant: 90),
+            mealImageView.heightAnchor.constraint(equalToConstant: 60),
+            
+            mealImageView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 12),
+            mealImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -12),
+            
+            mealNameLabel.leadingAnchor.constraint(equalTo: mealImageView.trailingAnchor, constant: 16),
+            mealNameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            mealNameLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ])
+    }
+}

--- a/PocketChef/Features/Meals/View/MealsView.swift
+++ b/PocketChef/Features/Meals/View/MealsView.swift
@@ -13,7 +13,7 @@ final class MealsView: UIView {
     let tableView: UITableView = {
         let tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "MealCell")
+        tableView.rowHeight = 80
         return tableView
     }()
     

--- a/PocketChef/Features/Meals/View/MealsViewController.swift
+++ b/PocketChef/Features/Meals/View/MealsViewController.swift
@@ -47,6 +47,7 @@ final class MealsViewController: UIViewController {
     private func setupTableView() {
         customView?.tableView.dataSource = self
         customView?.tableView.delegate = self
+        customView?.tableView.register(MealCell.self, forCellReuseIdentifier: MealCell.reuseIdentifier)
     }
     
     private func setupBindings() {
@@ -68,12 +69,13 @@ extension MealsViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "MealCell", for: indexPath)
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: MealCell.reuseIdentifier, for: indexPath) as? MealCell else {
+            return UITableViewCell()
+        }
         
         if let meal = viewModel.meal(at: indexPath.row) {
-            var content = cell.defaultContentConfiguration()
-            content.text = meal.name
-            cell.contentConfiguration = content
+            let imageURL = URL(string: meal.thumbnailURLString)
+            cell.configure(with: meal.name, imageURL: imageURL)
         }
         
         return cell

--- a/PocketChef/Features/Search/View/SearchView.swift
+++ b/PocketChef/Features/Search/View/SearchView.swift
@@ -21,7 +21,7 @@ final class SearchView: UIView {
     let tableView: UITableView = {
         let tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "SearchResultCell")
+        tableView.rowHeight = 80
         return tableView
     }()
     

--- a/PocketChef/Features/Search/View/SearchViewController.swift
+++ b/PocketChef/Features/Search/View/SearchViewController.swift
@@ -39,6 +39,7 @@ final class SearchViewController: UIViewController {
         title = "Search"
         customView?.tableView.dataSource = self
         customView?.searchBar.delegate = self
+        customView?.tableView.register(MealCell.self, forCellReuseIdentifier: MealCell.reuseIdentifier)
     }
     
     private func setupBindings() {
@@ -58,14 +59,14 @@ extension SearchViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "SearchResultCell", for: indexPath)
-        
-        if let meal = viewModel.result(at: indexPath.row) {
-            var content = cell.defaultContentConfiguration()
-            content.text = meal.name
-            cell.contentConfiguration = content
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: MealCell.reuseIdentifier, for: indexPath) as? MealCell else {
+            return UITableViewCell()
         }
         
+        if let meal = viewModel.result(at: indexPath.row) {
+            let imageURL = URL(string: meal.thumbnailURLString ?? "")
+            cell.configure(with: meal.name, imageURL: imageURL)
+        }
         return cell
     }
 }


### PR DESCRIPTION
Summary
This PR significantly improves the user experience by replacing the default, text-only table view cells with a custom MealCell. This new cell displays a thumbnail image of the meal alongside its name, making the lists much more visually appealing and informative.

The MealCell was designed as a reusable component and has been integrated into both the category-filtered meal list and the search results list, ensuring a consistent UI across the application.

Key Implementation Details
Reusable MealCell Component:

A new MealCell.swift file (subclass of UITableViewCell) was created in a shared Core/UIComponents directory.

The cell's layout, containing a UIImageView and a UILabel, is built programmatically using Auto Layout.

A public configure(with:imageURL:) method encapsulates the cell's population logic, making it decoupled and easy to use from any view controller.

Integration:

The MealsViewController and SearchViewController were both updated to register and dequeue the new MealCell.

The cellForRowAt datasource methods in both controllers were simplified to call the cell's configure method.

UI Polish:

A fixed rowHeight was set on the table views to ensure the cell has adequate space to display its content correctly.

How to Test
Pull down this branch (feature/custom-meal-cell).

Run the app.

Navigate to a meals list by tapping a category. The list should now display images next to each meal name.

Go to the "Search" tab and search for a meal (e.g., "chicken"). The results list should also use the new custom cell with images, providing a consistent look and feel.