### PR TITLE
feat: Enable navigation from search to meal details

### DIFF
--- a/PocketChef/Core/Coordinator/SearchCoordinator.swift
+++ b/PocketChef/Core/Coordinator/SearchCoordinator.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-final class SearchCoordinator: Coordinator {
+final class SearchCoordinator: Coordinator, SearchViewControllerDelegate {
     var navigationController: UINavigationController
     
     init(navigationController: UINavigationController) {
@@ -17,6 +17,23 @@ final class SearchCoordinator: Coordinator {
     
     func start() {
         let searchViewController = SearchViewController()
+        searchViewController.delegate = self
         navigationController.pushViewController(searchViewController, animated: false)
+    }
+    
+    func showMealDetails(for meal: MealDetails) {
+        let mealSummary = Meal(id: meal.id,
+                               name: meal.name,
+                               thumbnailURLString: meal.thumbnailURLString ?? "")
+        
+        let viewModel = MealDetailsViewModel(meal: mealSummary)
+        let viewController = MealDetailsViewController(viewModel: viewModel)
+        navigationController.pushViewController(viewController, animated: true)
+    }
+}
+
+extension SearchCoordinator {
+    func searchViewController(_ controller: SearchViewController, didSelectMeal meal: MealDetails) {
+        showMealDetails(for: meal)
     }
 }

--- a/PocketChef/Features/Search/View/SearchViewController.swift
+++ b/PocketChef/Features/Search/View/SearchViewController.swift
@@ -11,6 +11,8 @@ import UIKit
 final class SearchViewController: UIViewController {
     
     private let viewModel: SearchViewModelProtocol
+    weak var delegate: SearchViewControllerDelegate?
+    
     private var customView: SearchView? {
         return view as? SearchView
     }
@@ -39,6 +41,7 @@ final class SearchViewController: UIViewController {
         title = "Search"
         customView?.tableView.dataSource = self
         customView?.searchBar.delegate = self
+        customView?.tableView.delegate = self
         customView?.tableView.register(MealCell.self, forCellReuseIdentifier: MealCell.reuseIdentifier)
     }
     
@@ -78,5 +81,14 @@ extension SearchViewController: UISearchBarDelegate {
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         searchBar.resignFirstResponder()
+    }
+}
+
+extension SearchViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let selectedMeal = viewModel.result(at: indexPath.row) else { return }
+        delegate?.searchViewController(self, didSelectMeal: selectedMeal)
     }
 }

--- a/PocketChef/Features/Search/View/SearchViewControllerDelegate.swift
+++ b/PocketChef/Features/Search/View/SearchViewControllerDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  SearchViewControllerDelegate.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 25/09/25.
+//
+
+import Foundation
+
+protocol SearchViewControllerDelegate: AnyObject {
+    func searchViewController(_ controller: SearchViewController, didSelectMeal meal: MealDetails)
+}


### PR DESCRIPTION
Summary
This PR completes the user flow for the search feature by enabling navigation from the search results list to the meal details screen. The search tab is now fully functional, allowing users to not only discover meals but also view their complete recipes.

This was achieved by implementing the delegate pattern to communicate user actions from the View back to the Coordinator.

Key Implementation Details
Delegate Pattern:

A new SearchViewControllerDelegate protocol was created to establish a communication contract between the search screen and its coordinator.

The SearchViewController was updated to conform to UITableViewDelegate, detect cell taps, and notify its delegate of the user's selection.

Coordinator Logic:

The SearchCoordinator now conforms to SearchViewControllerDelegate. It listens for selection events and is responsible for creating and presenting the meal details screen.

Component Reusability (DRY):

This implementation successfully reuses the existing MealDetailsViewModel and MealDetailsViewController without modification.

The SearchCoordinator acts as an "adapter" by creating the required Meal summary object from the MealDetails object provided by the delegate, further demonstrating the flexibility of the coordinator pattern.

How to Test
Pull down this branch (feature/search-navigation).

Run the app and select the "Search" tab.

Search for a meal (e.g., "chicken" or "salmon").

Tap on any meal in the results list.

The app should smoothly navigate to the detailed recipe view for the selected meal, displaying its image, ingredients, and instructions.

