### PR TITLE
refactor: Modernize app with async/await and Combine

### DIFF
--- a/PocketChef/Core/Networking/NetworkServiceProtocol.swift
+++ b/PocketChef/Core/Networking/NetworkServiceProtocol.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol NetworkServiceProtocol {
-    func request<T: Decodable>(urlString: String, completion: @escaping (Result<T, NetworkError>) -> Void)
+    func request<T: Decodable>(urlString: String) async throws -> T
 }

--- a/PocketChef/Features/Categories/ViewModel/CategoriesViewModelProtocol.swift
+++ b/PocketChef/Features/Categories/ViewModel/CategoriesViewModelProtocol.swift
@@ -6,11 +6,21 @@
 //
 
 import Foundation
+import Combine
 
 protocol CategoriesViewModelProtocol: AnyObject {
-    var onCategoriesUpdated: (() -> Void)? { get set }
-    var onFetchError: ((String) -> Void)? { get set }
+    
+    // MARK: - Publishers for Data Binding
+
+    var categoriesPublisher: AnyPublisher<[PocketChef.Category], Never> { get }
+    var errorPublisher: AnyPublisher<String, Never> { get }
+    
+    // MARK: - Data Source (agora derivado dos Publishers)
+    
     var numberOfCategories: Int { get }
-    func category(at index: Int) -> Category?
-    func fetchCategories()
+    func category(at index: Int) -> PocketChef.Category?
+    
+    // MARK: - View Actions
+    
+    func fetchCategories() async
 }

--- a/PocketChef/Features/MealDetails/ViewModel/MealDetailsViewModelProtocol.swift
+++ b/PocketChef/Features/MealDetails/ViewModel/MealDetailsViewModelProtocol.swift
@@ -6,14 +6,18 @@
 //
 
 import Foundation
+import Combine
 
 protocol MealDetailsViewModelProtocol: AnyObject {
-    var onDetailsUpdated: (() -> Void)? { get set }
-    var onFetchError: ((String) -> Void)? { get set }
+    
+    // MARK: - Publishers for Data Binding
+    var detailsPublisher: AnyPublisher<MealDetails, Never> { get }
+    var errorPublisher: AnyPublisher<String, Never> { get }
+    
+    // MARK: - Data Source
     var mealName: String { get }
     var mealThumbnailURL: URL? { get }
-    var instructions: String { get }
-    var ingredients: [MealDetails.Ingredient] { get }
     
-    func fetchDetails()
+    // MARK: - View Actions
+    func fetchDetails() async
 }

--- a/PocketChef/Features/Meals/ViewModel/MealsViewModelProtocol.swift
+++ b/PocketChef/Features/Meals/ViewModel/MealsViewModelProtocol.swift
@@ -6,13 +6,19 @@
 //
 
 import Foundation
+import Combine
 
 protocol MealsViewModelProtocol: AnyObject {
-    var onMealsUpdated: (() -> Void)? { get set }
-    var onFetchError: ((String) -> Void)? { get set }
+    
+    // MARK: - Publishers for Data Binding
+    var mealsPublisher: AnyPublisher<[Meal], Never> { get }
+    var errorPublisher: AnyPublisher<String, Never> { get }
+    
+    // MARK: - Data Source
     var screenTitle: String { get }
     var numberOfMeals: Int { get }
-    
     func meal(at index: Int) -> Meal?
-    func fetchMeals()
+    
+    // MARK: - View Actions
+    func fetchMeals() async
 }

--- a/PocketChef/Features/Search/View/SearchViewController.swift
+++ b/PocketChef/Features/Search/View/SearchViewController.swift
@@ -7,29 +7,35 @@
 
 import Foundation
 import UIKit
+import Combine
 
 final class SearchViewController: UIViewController {
-    
+
+    // MARK: - Properties
     private let viewModel: SearchViewModelProtocol
     weak var delegate: SearchViewControllerDelegate?
-    
+
     private var customView: SearchView? {
         return view as? SearchView
     }
-    
+
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Initialization
     init(viewModel: SearchViewModelProtocol = SearchViewModel()) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
+    // MARK: - Lifecycle
     override func loadView() {
         self.view = SearchView()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -37,22 +43,29 @@ final class SearchViewController: UIViewController {
         setupBindings()
     }
     
+    // MARK - Private Methods
     private func setupUI() {
         title = "Search"
         customView?.tableView.dataSource = self
-        customView?.searchBar.delegate = self
         customView?.tableView.delegate = self
+        customView?.searchBar.delegate = self
         customView?.tableView.register(MealCell.self, forCellReuseIdentifier: MealCell.reuseIdentifier)
     }
-    
+
     private func setupBindings() {
-        viewModel.onSearchResultsUpdated = { [weak self] in
-            self?.customView?.tableView.reloadData()
-        }
-        
-        viewModel.onFetchError = { [weak self] errorMessage in
-            print("Search Error: \(errorMessage)")
-        }
+        viewModel.searchResultsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.customView?.tableView.reloadData()
+            }
+            .store(in: &cancellables)
+
+        viewModel.errorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] errorMessage in
+                print("Search Error: \(errorMessage)")
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -60,7 +73,7 @@ extension SearchViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.numberOfResults
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: MealCell.reuseIdentifier, for: indexPath) as? MealCell else {
             return UITableViewCell()
@@ -70,25 +83,31 @@ extension SearchViewController: UITableViewDataSource {
             let imageURL = URL(string: meal.thumbnailURLString ?? "")
             cell.configure(with: meal.name, imageURL: imageURL)
         }
+        
         return cell
     }
 }
 
-extension SearchViewController: UISearchBarDelegate {
-    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        viewModel.search(for: searchText)
-    }
-    
-    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        searchBar.resignFirstResponder()
+extension SearchViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        guard let selectedMeal = viewModel.result(at: indexPath.row) else { return }
+        
+        delegate?.searchViewController(self, didSelectMeal: selectedMeal)
     }
 }
 
-extension SearchViewController: UITableViewDelegate {
-    
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        guard let selectedMeal = viewModel.result(at: indexPath.row) else { return }
-        delegate?.searchViewController(self, didSelectMeal: selectedMeal)
+
+// MARK: - UISearchBarDelegate
+extension SearchViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        Task {
+            await viewModel.search(for: searchText)
+        }
+    }
+
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
     }
 }

--- a/PocketChef/Features/Search/ViewModel/SearchViewModelProtocol.swift
+++ b/PocketChef/Features/Search/ViewModel/SearchViewModelProtocol.swift
@@ -6,13 +6,18 @@
 //
 
 import Foundation
+import Combine
 
 protocol SearchViewModelProtocol: AnyObject {
     
-    var onSearchResultsUpdated: (() -> Void)? { get set }
-    var onFetchError: ((String) -> Void)? { get set }
-    var numberOfResults: Int { get }
+    // MARK: - Publishers for Data Binding
+    var searchResultsPublisher: AnyPublisher<[PocketChef.MealDetails], Never> { get }
+    var errorPublisher: AnyPublisher<String, Never> { get }
     
-    func result(at index: Int) -> MealDetails?
-    func search(for query: String)
+    // MARK: - Data Source
+    var numberOfResults: Int { get }
+    func result(at index: Int) -> PocketChef.MealDetails?
+    
+    // MARK: - View Actions
+    func search(for query: String) async
 }


### PR DESCRIPTION
Summary
This PR represents a significant architectural refactor of the entire application to adopt modern Swift concurrency and data binding patterns. The goal was to improve code readability, safety, and maintainability by replacing closure-based completion handlers and data binding with async/await and the Combine framework, respectively.

While this change does not alter the app's external behavior, it dramatically modernizes the underlying codebase to align with the latest industry best practices.

Key Implementation Details
Networking Layer (async/await):

The NetworkService and its protocol were completely rewritten. The old completion-handler-based request method was replaced with a modern async throws function.

This change leverages URLSession's new async methods, resulting in cleaner, linear, and more readable network call sites.

ViewModel State Management (Combine):

All ViewModels (CategoriesViewModel, MealsViewModel, MealDetailsViewModel, SearchViewModel) were updated to use the Combine framework for publishing state changes.

Custom data binding closures (onUpdated, onError) were replaced with a reactive pattern using PassthroughSubject and exposing them as type-erased AnyPublishers for better encapsulation.

UI Layer Integration:

All ViewControllers were updated to subscribe to the new Combine publishers from their respective ViewModels.

Subscriptions are managed using a Set<AnyCancellable> to prevent memory leaks.

The .receive(on: DispatchQueue.main) operator is used on all subscriptions to guarantee that UI updates are safely performed on the main thread.

Asynchronous ViewModel methods are now called from within a Task block (e.g., in viewDidLoad and UISearchBarDelegate).

Modernized Debouncing:

The search debouncing logic in SearchViewModel was refactored to use a cancellable Task and Task.sleep, replacing the older DispatchWorkItem approach for a more modern and integrated solution.

How to Test
As this is a refactoring PR, the primary goal is to ensure no regressions were introduced.

Pull down this branch (refactor/async-await-networking).

Run the app.

Thoroughly test all existing user flows:

Navigate from the "Categories" tab -> Meals List -> Meal Details.

Use the "Search" tab to find meals and navigate to their details.

Confirm that all functionality (loading data, navigation, searching) works exactly as it did before the refactor.