### PR TITLE
feat: Implement search history with state machine refactor

### DIFF
--- a/PocketChef/Core/Persistence/SearchHistoryStore.swift
+++ b/PocketChef/Core/Persistence/SearchHistoryStore.swift
@@ -1,0 +1,14 @@
+//
+//  SearchHistoryStore.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 01/10/25.
+//
+
+import Foundation
+
+protocol SearchHistoryStore {
+    func save(searchTerm term: String)
+    func getSearchHistory() -> [String]
+    func clearSearchHistory()
+}

--- a/PocketChef/Core/Persistence/UserDefaultsSearchHistoryStore.swift
+++ b/PocketChef/Core/Persistence/UserDefaultsSearchHistoryStore.swift
@@ -1,0 +1,42 @@
+//
+//  UserDefaultsSearchHistoryStore.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 01/10/25.
+//
+
+import Foundation
+
+final class UserDefaultsSearchHistoryStore: SearchHistoryStore {
+    
+    // MARK: - Private Properties
+    private let userDefaults: UserDefaults
+    private static let historyKey = "SearchHistory"
+    private let maxHistoryCount = 10
+    
+    // MARK: - Initialization
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+    
+    // MARK: - SearchHistoryStore Conformance
+    func save(searchTerm term: String) {
+        let trimmedTerm = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTerm.isEmpty else { return }
+        
+        var history = getSearchHistory()
+        history.removeAll { $0.lowercased() == trimmedTerm.lowercased() }
+        history.insert(trimmedTerm, at: 0)
+        
+        let limitedHistory = Array(history.prefix(maxHistoryCount))
+        userDefaults.set(limitedHistory, forKey: Self.historyKey)
+    }
+    
+    func getSearchHistory() -> [String] {
+        return userDefaults.stringArray(forKey: Self.historyKey) ?? []
+    }
+    
+    func clearSearchHistory() {
+        userDefaults.removeObject(forKey: Self.historyKey)
+    }
+}

--- a/PocketChef/Features/MealDetails/Model/MealDetails.swift
+++ b/PocketChef/Features/MealDetails/Model/MealDetails.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct MealDetailsResponse: Decodable {
-    let meals: [MealDetails]
+    let meals: [MealDetails]?
 }
 
 struct MealDetails: Decodable {

--- a/PocketChef/Features/MealDetails/ViewModel/MealDetailsViewModel.swift
+++ b/PocketChef/Features/MealDetails/ViewModel/MealDetailsViewModel.swift
@@ -50,7 +50,7 @@ final class MealDetailsViewModel: MealDetailsViewModelProtocol {
         do {
             let response: MealDetailsResponse = try await networkService.request(urlString: urlString)
             
-            if let details = response.meals.first {
+            if let details = response.meals?.first {
                 detailsSubject.send(details)
             } else {
                 throw NetworkError.invalidResponse

--- a/PocketChef/Features/Search/ViewModel/SearchViewModelProtocol.swift
+++ b/PocketChef/Features/Search/ViewModel/SearchViewModelProtocol.swift
@@ -8,16 +8,22 @@
 import Foundation
 import Combine
 
+enum SearchState {
+    case idle
+    case loading
+    case showingHistory([String])
+    case showingResults([PocketChef.MealDetails])
+    case error(String)
+}
+
+
+
 protocol SearchViewModelProtocol: AnyObject {
     
     // MARK: - Publishers for Data Binding
-    var searchResultsPublisher: AnyPublisher<[PocketChef.MealDetails], Never> { get }
-    var errorPublisher: AnyPublisher<String, Never> { get }
-    
-    // MARK: - Data Source
-    var numberOfResults: Int { get }
-    func result(at index: Int) -> PocketChef.MealDetails?
+    var statePublisher: AnyPublisher<SearchState, Never> { get }
     
     // MARK: - View Actions
+    func loadInitialState()
     func search(for query: String)
 }

--- a/PocketChef/Features/Search/ViewModel/ViewModel.swift
+++ b/PocketChef/Features/Search/ViewModel/ViewModel.swift
@@ -12,65 +12,58 @@ import Combine
 final class SearchViewModel: SearchViewModelProtocol {
     
     // MARK: - Publishers (Data Binding)
-    var searchResultsPublisher: AnyPublisher<[PocketChef.MealDetails], Never> {
-        searchResultsSubject.eraseToAnyPublisher()
-    }
-    
-    var errorPublisher: AnyPublisher<String, Never> {
-        errorSubject.eraseToAnyPublisher()
+    var statePublisher: AnyPublisher<SearchState, Never> {
+        stateSubject.eraseToAnyPublisher()
     }
     
     // MARK: - Private Properties
-    private let searchResultsSubject = PassthroughSubject<[PocketChef.MealDetails], Never>()
-    private let errorSubject = PassthroughSubject<String, Never>()
+    private let stateSubject = CurrentValueSubject<SearchState, Never>(.idle)
     
-    private var searchResults: [PocketChef.MealDetails] = []
     private let networkService: NetworkServiceProtocol
+    private let searchHistoryStore: SearchHistoryStore
+    
     private let baseURL = "https://www.themealdb.com/api/json/v1/1/search.php?s="
     private var searchTask: Task<Void, Never>?
 
     // MARK: - Initialization
-    init(networkService: NetworkServiceProtocol = NetworkService()) {
+    init(networkService: NetworkServiceProtocol = NetworkService(),
+         searchHistoryStore: SearchHistoryStore = UserDefaultsSearchHistoryStore()) {
         self.networkService = networkService
-    }
-    
-    // MARK: - Data Source
-    var numberOfResults: Int {
-        return searchResults.count
-    }
-    
-    func result(at index: Int) -> PocketChef.MealDetails? {
-        guard index >= 0 && index < searchResults.count else { return nil }
-        return searchResults[index]
+        self.searchHistoryStore = searchHistoryStore
     }
     
     // MARK: - View Actions
+    func loadInitialState() {
+        let history = searchHistoryStore.getSearchHistory()
+        stateSubject.send(.showingHistory(history))
+    }
+    
     func search(for query: String) {
         searchTask?.cancel()
         
-        guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
-            self.searchResults = []
-            self.searchResultsSubject.send(self.searchResults)
+        let trimmedQuery = query.trimmingCharacters(in: .whitespaces)
+        
+        guard !trimmedQuery.isEmpty else {
+            loadInitialState()
             return
         }
-
+        
+        stateSubject.send(.loading)
+        
         searchTask = Task {
             do {
                 try await Task.sleep(nanoseconds: 500_000_000)
-            
-                let response: MealDetailsResponse = try await networkService.request(urlString: baseURL + query)
-                self.searchResults = (response.meals ?? []).sorted { $0.name < $1.name }
-                self.searchResultsSubject.send(self.searchResults)
+                
+                let response: MealDetailsResponse = try await networkService.request(urlString: baseURL + trimmedQuery)
+                let results = response.meals ?? []
+                
+                searchHistoryStore.save(searchTerm: trimmedQuery)
+                stateSubject.send(.showingResults(results))
                 
             } catch is CancellationError {
                 return
             } catch {
-                if let networkError = error as? NetworkError, case .decodingFailed = networkError {
-                    self.searchResults = []
-                    self.searchResultsSubject.send(self.searchResults)
-                } else {
-                    self.errorSubject.send(error.localizedDescription)
-                }
+                stateSubject.send(.error(error.localizedDescription))
             }
         }
     }

--- a/PocketChefTests/Features/Search/ViewModel/SearchViewModelTests.swift
+++ b/PocketChefTests/Features/Search/ViewModel/SearchViewModelTests.swift
@@ -16,64 +16,85 @@ final class SearchViewModelTests: XCTestCase {
     // MARK: - Properties
     private var sut: SearchViewModel!
     private var mockNetworkService: MockNetworkService!
+    private var mockHistoryStore: MockSearchHistoryStore!
     private var cancellables: Set<AnyCancellable>!
 
     // MARK: - Lifecycle
     override func setUp() {
         super.setUp()
         mockNetworkService = MockNetworkService()
-        sut = SearchViewModel(networkService: mockNetworkService)
+        mockHistoryStore = MockSearchHistoryStore()
+        sut = SearchViewModel(
+            networkService: mockNetworkService,
+            searchHistoryStore: mockHistoryStore
+        )
         cancellables = []
     }
 
     override func tearDown() {
         sut = nil
         mockNetworkService = nil
+        mockHistoryStore = nil
         cancellables = nil
         super.tearDown()
     }
 
     // MARK: - Test Cases
-    func testSearch_WhenRequestSucceeds_ShouldPublishResults() async {
-        let mockMeal = PocketChef.MealDetails(id: "52771", name: "Arrabiata", instructions: "", thumbnailURLString: nil, ingredients: [])
-        let mockResponse = MealDetailsResponse(meals: [mockMeal])
-        mockNetworkService.mockResult = .success(mockResponse)
+    func testLoadInitialState_WhenHistoryExists_ShouldPublishShowingHistoryState() {
         
-        let expectation = self.expectation(description: "Publishes search results")
-        var receivedResults: [PocketChef.MealDetails] = []
+        let history = ["chicken", "beef"]
+        mockHistoryStore.mockHistory = history
+        let expectation = self.expectation(description: "Publishes .showingHistory state")
+        var receivedState: SearchState?
         
-        sut.searchResultsPublisher
-            .sink { results in
-                receivedResults = results
+        sut.statePublisher
+            .dropFirst()
+            .sink { state in
+                receivedState = state
                 expectation.fulfill()
             }
             .store(in: &cancellables)
 
-        sut.search(for: "Arrabiata")
-        await fulfillment(of: [expectation], timeout: 2.0)
+        sut.loadInitialState()
         
-        XCTAssertEqual(receivedResults.count, 1)
-        XCTAssertEqual(receivedResults.first?.name, "Arrabiata")
+        waitForExpectations(timeout: 1.0)
+        
+        guard case .showingHistory(let receivedHistory) = receivedState else {
+            XCTFail("Expected .showingHistory state, but got \(String(describing: receivedState))")
+            return
+        }
+        XCTAssertEqual(receivedHistory, history)
     }
     
-    func testSearch_WhenQueryChangesRapidly_ShouldCallNetworkOnlyOnce() async {
-        let mockMeal = PocketChef.MealDetails(id: "52771", name: "Arrabiata", instructions: "", thumbnailURLString: nil, ingredients: [])
+    func testSearch_WhenRequestSucceeds_ShouldSaveTermAndPublishResults() {
+        let query = "Arrabiata"
+        let mockMeal = PocketChef.MealDetails(id: "52771", name: query, instructions: "", thumbnailURLString: nil, ingredients: [])
         let mockResponse = MealDetailsResponse(meals: [mockMeal])
         mockNetworkService.mockResult = .success(mockResponse)
         
-        let expectation = self.expectation(description: "The final search query should publish results")
+        let expectation = self.expectation(description: "Publishes .showingResults state")
+        var finalState: SearchState?
         
-        sut.searchResultsPublisher
-            .sink { _ in
-                expectation.fulfill()
+        sut.statePublisher
+            .dropFirst()
+            .sink { state in
+                if case .showingResults = state {
+                    finalState = state
+                    expectation.fulfill()
+                }
             }
             .store(in: &cancellables)
 
-        sut.search(for: "a")
-        sut.search(for: "ar")
-        sut.search(for: "arr")
+        sut.search(for: query)
         
-        await fulfillment(of: [expectation], timeout: 2.0)
-        XCTAssertEqual(mockNetworkService.requestCallCount, 1, "Network service should only be called once due to debouncing.")
+        waitForExpectations(timeout: 2.0)
+        
+        guard case .showingResults(let results) = finalState else {
+            XCTFail("Expected .showingResults, but got \(String(describing: finalState))")
+            return
+        }
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.name, query)
+        XCTAssertTrue(mockHistoryStore.mockHistory.contains(query))
     }
 }

--- a/PocketChefTests/Mocks/MockSearchHistoryStore.swift
+++ b/PocketChefTests/Mocks/MockSearchHistoryStore.swift
@@ -1,0 +1,27 @@
+//
+//  MockSearchHistoryStore.swift
+//  PocketChefTests
+//
+//  Created by Rodrigo Cerqueira Reis on 02/10/25.
+//
+
+import Foundation
+@testable import PocketChef
+
+final class MockSearchHistoryStore: SearchHistoryStore {
+    
+    var mockHistory: [String] = []
+    
+    func save(searchTerm term: String) {
+        mockHistory.removeAll { $0 == term }
+        mockHistory.insert(term, at: 0)
+    }
+    
+    func getSearchHistory() -> [String] {
+        return mockHistory
+    }
+    
+    func clearSearchHistory() {
+        mockHistory.removeAll()
+    }
+}


### PR DESCRIPTION
Summary
This PR introduces a search history feature. User searches are now persisted locally using UserDefaults and are displayed when the search bar is active but empty. Tapping a history item re-executes the search for that term.

To implement this cleanly, the SearchViewModel was significantly refactored into a state machine, where the UI is driven by a single State enum.

Key Implementation Details
State-Driven UI Refactor:

The SearchViewModel was refactored to manage its logic via a SearchState enum (.idle, .loading, .showingHistory, .showingResults, .error).

It now exposes a single statePublisher that emits the current state. The SearchViewController subscribes to this publisher and uses a switch statement to update its UI, making it a robust, state-driven component.

New Persistence Layer:

A new, protocol-based persistence layer was created (SearchHistoryStore).

A concrete UserDefaultsSearchHistoryStore was implemented to save, retrieve, and manage the list of recent search terms, including logic to handle duplicates and limit the history size.

This service is injected into the SearchViewModel, ensuring the components remain decoupled and testable.

Updated Unit Tests:

A MockSearchHistoryStore was created for testing purposes.

The SearchViewModelTests suite was rewritten to validate the new state machine logic, including tests for the .showingHistory state and verifying that search terms are correctly saved.

How to Test
Pull down this branch (feature/search-history).

Run the app and navigate to the "Search" tab.

Perform a few searches (e.g., "chicken", then "pork").

Clear the search bar text. Verify: The search terms "pork" and "chicken" should appear in the list as history items.

Close and restart the application. Navigate back to the "Search" tab. Verify: The search history persists and is displayed immediately.

Tap on a history item (e.g., "chicken"). Verify: A search for "chicken" is automatically performed.

Run the unit tests (Cmd + U). Verify: All tests should pass.