### PR TITLE
feat: Enhance search history UI and add delete functionality

### DIFF
--- a/PocketChef/Core/Persistence/SearchHistoryStore.swift
+++ b/PocketChef/Core/Persistence/SearchHistoryStore.swift
@@ -11,4 +11,5 @@ protocol SearchHistoryStore {
     func save(searchTerm term: String)
     func getSearchHistory() -> [String]
     func clearSearchHistory()
+    func remove(searchTerm term: String)
 }

--- a/PocketChef/Core/Persistence/UserDefaultsSearchHistoryStore.swift
+++ b/PocketChef/Core/Persistence/UserDefaultsSearchHistoryStore.swift
@@ -32,6 +32,12 @@ final class UserDefaultsSearchHistoryStore: SearchHistoryStore {
         userDefaults.set(limitedHistory, forKey: Self.historyKey)
     }
     
+    func remove(searchTerm term: String) {
+        var history = getSearchHistory()
+        history.removeAll { $0.lowercased() == term.lowercased() }
+        userDefaults.set(history, forKey: Self.historyKey)
+    }
+    
     func getSearchHistory() -> [String] {
         return userDefaults.stringArray(forKey: Self.historyKey) ?? []
     }

--- a/PocketChef/Core/UIComponents/HistoryCell.swift
+++ b/PocketChef/Core/UIComponents/HistoryCell.swift
@@ -1,0 +1,102 @@
+//
+//  HistoryCell.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 02/10/25.
+//
+
+import Foundation
+import UIKit
+
+final class HistoryCell: UITableViewCell {
+    
+    // MARK: - Static Properties
+    static let reuseIdentifier = "HistoryCell"
+    
+    // MARK: - Callback
+    var onDeleteButtonTapped: (() -> Void)?
+    
+    // MARK: - UI Components
+    private let clockIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        let config = UIImage.SymbolConfiguration(textStyle: .body)
+        imageView.image = UIImage(systemName: "clock", withConfiguration: config)
+        imageView.tintColor = .secondaryLabel
+        imageView.contentMode = .center
+        return imageView
+    }()
+    
+    private let termLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 17, weight: .regular)
+        label.textColor = .label
+        return label
+    }()
+    
+    private let deleteButton: UIButton = {
+        let button = UIButton()
+        let config = UIImage.SymbolConfiguration(textStyle: .body)
+        let image = UIImage(systemName: "xmark", withConfiguration: config)
+        button.setImage(image, for: .normal)
+        button.tintColor = .tertiaryLabel
+        return button
+    }()
+    
+    private let mainStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 12
+        stackView.alignment = .center
+        return stackView
+    }()
+    
+    // MARK: - Initialization
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupView()
+        setupActions()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Public Methods
+    func configure(with term: String) {
+        termLabel.text = term
+    }
+    
+    // MARK: - Private Methods
+    private func setupView() {
+        var backgroundConfig = UIBackgroundConfiguration.listPlainCell()
+        backgroundConfig.backgroundColor = .clear
+        self.backgroundConfiguration = backgroundConfig
+        
+        mainStackView.addArrangedSubview(clockIconImageView)
+        mainStackView.addArrangedSubview(termLabel)
+        mainStackView.addArrangedSubview(deleteButton)
+        
+        contentView.addSubview(mainStackView)
+        
+        let iconWidth: CGFloat = 24
+        
+        NSLayoutConstraint.activate([
+            mainStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            mainStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            mainStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12),
+            
+            clockIconImageView.widthAnchor.constraint(equalToConstant: iconWidth),
+            deleteButton.widthAnchor.constraint(equalToConstant: iconWidth)
+        ])
+    }
+    
+    private func setupActions() {
+        deleteButton.addTarget(self, action: #selector(deleteButtonWasTapped), for: .touchUpInside)
+    }
+    
+    @objc private func deleteButtonWasTapped() {
+        onDeleteButtonTapped?()
+    }
+}

--- a/PocketChef/Features/Search/View/SearchViewController.swift
+++ b/PocketChef/Features/Search/View/SearchViewController.swift
@@ -56,7 +56,7 @@ final class SearchViewController: UIViewController {
         customView?.tableView.delegate = self
         customView?.searchBar.delegate = self
         customView?.tableView.register(MealCell.self, forCellReuseIdentifier: MealCell.reuseIdentifier)
-        customView?.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "HistoryCell")
+        customView?.tableView.register(HistoryCell.self, forCellReuseIdentifier: HistoryCell.reuseIdentifier)
     }
 
     private func setupBindings() {
@@ -100,23 +100,29 @@ extension SearchViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return !searchResults.isEmpty ? searchResults.count : searchHistory.count
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if !searchResults.isEmpty {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: MealCell.reuseIdentifier, for: indexPath) as? MealCell else {
                 return UITableViewCell()
             }
-            
             let meal = searchResults[indexPath.row]
             let imageURL = URL(string: meal.thumbnailURLString ?? "")
             cell.configure(with: meal.name, imageURL: imageURL)
             return cell
+
         } else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "HistoryCell", for: indexPath)
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: HistoryCell.reuseIdentifier, for: indexPath) as? HistoryCell else {
+                return UITableViewCell()
+            }
+
             let term = searchHistory[indexPath.row]
-            var content = cell.defaultContentConfiguration()
-            content.text = term
-            cell.contentConfiguration = content
+            cell.configure(with: term)
+
+            cell.onDeleteButtonTapped = { [weak self] in
+                self?.viewModel.deleteHistory(term: term)
+            }
+
             return cell
         }
     }

--- a/PocketChef/Features/Search/ViewModel/SearchViewModelProtocol.swift
+++ b/PocketChef/Features/Search/ViewModel/SearchViewModelProtocol.swift
@@ -26,4 +26,5 @@ protocol SearchViewModelProtocol: AnyObject {
     // MARK: - View Actions
     func loadInitialState()
     func search(for query: String)
+    func deleteHistory(term: String) 
 }

--- a/PocketChef/Features/Search/ViewModel/ViewModel.swift
+++ b/PocketChef/Features/Search/ViewModel/ViewModel.swift
@@ -67,4 +67,11 @@ final class SearchViewModel: SearchViewModelProtocol {
             }
         }
     }
+    
+    func deleteHistory(term: String) {
+        searchHistoryStore.remove(searchTerm: term)
+        
+        let updatedHistory = searchHistoryStore.getSearchHistory()
+        stateSubject.send(.showingHistory(updatedHistory))
+    }
 }


### PR DESCRIPTION
Summary
This PR enhances the search history feature with significant UI and functionality improvements. History items are now displayed in a new custom HistoryCell with a distinct icon, and users now have the ability to delete individual items from their search history.

This was implemented as a full-stack feature, touching the UI, ViewModel, and Persistence layers.

Key Implementation Details
New HistoryCell Component:

A new reusable HistoryCell was created, displaying a clock icon (SF Symbol), the search term, and a delete button ('x').

The layout is managed by a UIStackView.

Cell-to-ViewController Communication (Callback):

The HistoryCell uses a closure-based callback (onDeleteButtonTapped) to notify the SearchViewController when a delete action is triggered. This provides a clean and decoupled way to handle actions from within a cell.

Full-Stack Delete Functionality:

The delete action propagates through all layers of the architecture:

View: SearchViewController receives the callback and calls the ViewModel with the specific term to delete.

ViewModel: SearchViewModel was updated with a deleteHistory(term:) method.

Persistence: The SearchHistoryStore protocol and its UserDefaults implementation were extended with a remove(searchTerm:) method to handle the data deletion.

After deletion, the ViewModel re-fetches the updated history and publishes a new .showingHistory state, causing the UI to update reactively.

How to Test
Pull down this branch (feature/enhance-search-history).

Run the app and navigate to the "Search" tab.

Perform a few searches to create a history list.

Clear the search bar. Verify: The history items now appear in the new cell format, with a clock icon on the left and an 'x' button on the right.

Tap the 'x' button next to any history item. Verify: The item is immediately removed from the list.

Close and restart the application. Go back to the search history. Verify: The item remains deleted, confirming the change was persisted correctly.