### PR TITLE
feat: Implement empty state view for search

### DIFF
--- a/PocketChef/Core/UIComponents/EmptyStateView.swift
+++ b/PocketChef/Core/UIComponents/EmptyStateView.swift
@@ -1,0 +1,74 @@
+//
+//  EmptyStateView.swift
+//  PocketChef
+//
+//  Created by Rodrigo Cerqueira Reis on 02/10/25.
+//
+
+import Foundation
+import UIKit
+
+final class EmptyStateView: UIView {
+    
+    // MARK: - UI Components
+    private let messageLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 18, weight: .semibold)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+    
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        let config = UIImage.SymbolConfiguration(pointSize: 60, weight: .light)
+        imageView.image = UIImage(systemName: "magnifyingglass", withConfiguration: config)
+        imageView.tintColor = .tertiaryLabel
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 16
+        stackView.alignment = .center
+        return stackView
+    }()
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Public Methods
+    func configure(with message: String, iconName: String) {
+        messageLabel.text = message
+        
+        let config = UIImage.SymbolConfiguration(pointSize: 60, weight: .light)
+        iconImageView.image = UIImage(systemName: iconName, withConfiguration: config)
+    }
+    
+    // MARK: - Private Methods
+    private func setupView() {
+        stackView.addArrangedSubview(iconImageView)
+        stackView.addArrangedSubview(messageLabel)
+        
+        addSubview(stackView)
+        
+        let padding: CGFloat = 40
+        
+        NSLayoutConstraint.activate([
+            stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: -padding),
+            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: padding),
+            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -padding)
+        ])
+    }
+}


### PR DESCRIPTION
Summary
This PR improves the user experience on the search screen by implementing a user-friendly empty state view. Instead of a blank screen, the user is now shown a contextual message when a search yields no results, when the search history is empty, or when a network error occurs.

This was achieved by creating a new reusable EmptyStateView component and integrating it into the SearchViewController's state-handling logic.

Key Implementation Details
Reusable EmptyStateView Component:

A new, generic EmptyStateView was created and added to the shared UIComponents.

The view is configurable with a custom message and SF Symbol icon, making it suitable for various empty or error states throughout the application in the future.

Integration via tableView.backgroundView:

The EmptyStateView is integrated into the SearchViewController using the idiomatic UITableView.backgroundView property.

This leverages the standard UIKit behavior where the backgroundView is automatically displayed when the table view's data source has zero rows.

Enhanced State Handling:

The handle(state:) method in SearchViewController was updated to explicitly configure the EmptyStateView's content for each relevant SearchState case.

When no search results are found, the view now displays a dynamic message that includes the user's original search term, providing better and more contextual feedback.

The EmptyStateView is also reused to display network error messages.

How to Test
Pull down this branch (feature/search-empty-state).

Run the app and navigate to the "Search" tab.

Test 1 (No History): If you have no search history, verify that a message like "Your recent searches will appear here." is displayed.

Test 2 (No Search Results): Search for a term that will yield no results (e.g., qwerty). Verify that a contextual message, such as No results found for "qwerty", is displayed.

Test 3 (Successful Search): Search for a term that returns results (e.g., "beef"). Verify that the empty state view is hidden and the search results are displayed correctly.

